### PR TITLE
change - help to -help

### DIFF
--- a/day5challenge/README.md
+++ b/day5challenge/README.md
@@ -51,7 +51,7 @@ Lets assume running the `git remote -v` returns something  different for you, th
 
 - Make Screenshot 
 
-- run `git <any-previous-command-learnt> - help `
+- run `git <any-previous-command-learnt> --help `
 
 - Make Screenshot 
 

--- a/day5challenge/README.md
+++ b/day5challenge/README.md
@@ -51,7 +51,7 @@ Lets assume running the `git remote -v` returns something  different for you, th
 
 - Make Screenshot 
 
-- run `git <any-previous-command-learnt> --help `
+- run `git <any-previous-command-learnt> -help `
 
 - Make Screenshot 
 


### PR DESCRIPTION
The git <command name> - help is a typo.